### PR TITLE
fix(inotion): mention in callout does not have to be a user

### DIFF
--- a/nhound/inotion.py
+++ b/nhound/inotion.py
@@ -67,6 +67,9 @@ class INotion:
             if block["type"] == "callout":
                 for item in block["callout"]["rich_text"]:
                     if item["type"] == "mention":
+                        if "user" not in item["mention"]:
+                            rlog.debug("No user in callout", item=item)
+                            continue
                         usr = self._cohort.get_by_uuid(item["mention"]["user"]["id"])
                         if usr is not None:
                             users.append(usr)


### PR DESCRIPTION
## Descriptions

A Notion mention can be a datetime, like `@today` which is useful to know when the page was updated.
